### PR TITLE
Changed format.type to format.raw.mimeType to fix video and audio filter in analyzer.ts

### DIFF
--- a/src/lib/analyzer.ts
+++ b/src/lib/analyzer.ts
@@ -38,7 +38,7 @@ export async function getBestFormats(url: string, preset: Preset): Promise<Forma
 function _createVideoFilter(preset: Preset) {
   return (format: MediaFormat) => {
 
-    if (!format.type || !ALLOWED_VIDEO_TYPES.includes(format.type)) {
+    if (!format.raw.mimeType || !ALLOWED_VIDEO_TYPES.includes(format.raw.mimeType)) {
       return false;
     }
 
@@ -75,7 +75,7 @@ function _createVideoCompare(preset: Preset): (a: MediaFormat, b: MediaFormat) =
 function _createAudioFilter(preset: Preset) {
   return (format: MediaFormat) => {
 
-    if (!format.type || !ALLOWED_AUDIO_TYPES.includes(format.type)) {
+    if (!format.raw.mimeType || !ALLOWED_AUDIO_TYPES.includes(format.raw.mimeType)) {
       return false;
     }
 


### PR DESCRIPTION
I wasn't able to use the program because the filters in analyzer.ts would always return an empty array, even if there were matching formats. After some digging around, I found out that the type was in raw.mimeType, not just type. 